### PR TITLE
getConverterClassName

### DIFF
--- a/src/main/ts/LongTextConverter.ts
+++ b/src/main/ts/LongTextConverter.ts
@@ -82,7 +82,7 @@ export class LongTextConverter {
     public getConverterClassNameWrapper(dosage: DosageWrapper): string {
         for (let converter of LongTextConverter._converters) {
             if (converter.canConvert(dosage, TextOptions.STANDARD)) {
-                return converter.constructor["name"];
+                return converter.getConverterClassName();
             }
         }
         return null;

--- a/src/main/ts/ShortTextConverter.ts
+++ b/src/main/ts/ShortTextConverter.ts
@@ -77,7 +77,7 @@ export class ShortTextConverter {
     public getConverterClassNameWrapper(dosage: DosageWrapper, maxLength: number = ShortTextConverter.MAX_LENGTH): string {
         for (let converter of ShortTextConverter._converters) {
             if (converter.canConvert(dosage) && converter.doConvert(dosage, TextOptions.STANDARD).length <= maxLength) {
-                return converter.constructor["name"];
+                return converter.getConverterClassName();
             }
         }
         return null;

--- a/src/main/ts/longtextconverterimpl/AdministrationAccordingToSchemaConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/AdministrationAccordingToSchemaConverterImpl.ts
@@ -4,6 +4,10 @@ import { SimpleLongTextConverterImpl } from "./SimpleLongTextConverterImpl";
 
 export class AdministrationAccordingToSchemaConverterImpl extends SimpleLongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "AdministrationAccordingToSchemaConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions): boolean {
         return dosage.isAdministrationAccordingToSchema();
     }

--- a/src/main/ts/longtextconverterimpl/BiWeeklyRepeatedConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/BiWeeklyRepeatedConverterImpl.ts
@@ -11,6 +11,10 @@ import { TextOptions } from "../TextOptions";
 
 export class BiWeeklyRepeatedConverterImpl extends WeeklyRepeatedConverterImpl {
 
+    public getConverterClassName(): string {
+        return "BiWeeklyRepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions): boolean {
         if (dosage.structures) {
 

--- a/src/main/ts/longtextconverterimpl/DailyRepeatedConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/DailyRepeatedConverterImpl.ts
@@ -9,6 +9,10 @@ import { TextOptions } from "../TextOptions";
 
 export class DailyRepeatedConverterImpl extends LongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "DailyRepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions): boolean {
         if (!dosage.structures)
             return false;

--- a/src/main/ts/longtextconverterimpl/DefaultLongTextConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/DefaultLongTextConverterImpl.ts
@@ -12,6 +12,10 @@ import { DateOrDateTimeWrapper } from "../vowrapper/DateOrDateTimeWrapper";
 export class DefaultLongTextConverterImpl extends LongTextConverterImpl {
 
 
+    public getConverterClassName(): string {
+        return "DefaultLongTextConverterImpl";
+    }
+
     longTextConverter: LongTextConverter;
 
     public constructor(longTextConverter: LongTextConverter) {

--- a/src/main/ts/longtextconverterimpl/DefaultMultiPeriodeLongTextConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/DefaultMultiPeriodeLongTextConverterImpl.ts
@@ -8,6 +8,10 @@ import { TextOptions } from "../TextOptions";
 
 export class DefaultMultiPeriodeLongTextConverterImpl extends LongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "DefaultMultiPeriodeLongTextConverterImpl";
+    }
+
     longTextConverter: LongTextConverter;
 
     public constructor(longTextConverter: LongTextConverter) {

--- a/src/main/ts/longtextconverterimpl/EmptyStructureConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/EmptyStructureConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextOptions } from "../TextOptions";
 
 export class EmptyStructureConverterImpl extends LongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "EmptyStructureConverterImpl";
+    }
+
     public canConvert(dosageStructure: DosageWrapper, options: TextOptions): boolean {
         return dosageStructure.isStructured()
             && dosageStructure.structures.getStructures()

--- a/src/main/ts/longtextconverterimpl/FreeTextConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/FreeTextConverterImpl.ts
@@ -4,6 +4,10 @@ import { TextOptions } from "../TextOptions";
 
 export class FreeTextConverterImpl extends SimpleLongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "FreeTextConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions): boolean {
         return dosage.freeText !== undefined && dosage.freeText !== null;
     }

--- a/src/main/ts/longtextconverterimpl/LongTextConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/LongTextConverterImpl.ts
@@ -11,6 +11,7 @@ import { MorningDoseWrapper, NoonDoseWrapper, EveningDoseWrapper, NightDoseWrapp
 
 export abstract class LongTextConverterImpl {
 
+    public abstract getConverterClassName(): string;
     public abstract canConvert(dosageStructure: DosageWrapper, options: TextOptions): boolean;
     public abstract doConvert(dosageStructure: DosageWrapper, options: TextOptions, currentTime: Date): string;
 

--- a/src/main/ts/longtextconverterimpl/RepeatedConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/RepeatedConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextOptions } from "../TextOptions";
 
 export class RepeatedConverterImpl extends LongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "RepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions): boolean {
         // Single period, single dosagedays, iterated
 

--- a/src/main/ts/longtextconverterimpl/RepeatedPNConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/RepeatedPNConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextOptions } from "../TextOptions";
 
 export class RepeatedPNConverterImpl extends LongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "RepeatedPNConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions): boolean {
         // Single period, single dosagedays, iterated
 

--- a/src/main/ts/longtextconverterimpl/TwoDaysRepeatedConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/TwoDaysRepeatedConverterImpl.ts
@@ -8,6 +8,10 @@ import { TextOptions } from "../TextOptions";
 
 export class TwoDaysRepeatedConverterImpl extends LongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "TwoDaysRepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions): boolean {
         if (dosage.structures) {
             if (dosage.structures.getStructures().length !== 1)

--- a/src/main/ts/longtextconverterimpl/WeeklyRepeatedConverterImpl.ts
+++ b/src/main/ts/longtextconverterimpl/WeeklyRepeatedConverterImpl.ts
@@ -13,6 +13,10 @@ import { DefaultLongTextConverterImpl } from "./DefaultLongTextConverterImpl";
 
 export class WeeklyRepeatedConverterImpl extends LongTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "WeeklyRepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper, options: TextOptions, ): boolean {
         if (dosage.structures) {
 

--- a/src/main/ts/shorttextconverterimpl/AdministrationAccordingToSchemaConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/AdministrationAccordingToSchemaConverterImpl.ts
@@ -3,6 +3,10 @@ import { DosageWrapper } from "../vowrapper/DosageWrapper";
 
 export class AdministrationAccordingToSchemaConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "AdministrationAccordingToSchemaConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         return dosage.isAdministrationAccordingToSchema();
     }

--- a/src/main/ts/shorttextconverterimpl/CombinedTwoPeriodesConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/CombinedTwoPeriodesConverterImpl.ts
@@ -9,6 +9,10 @@ import { TextHelper } from "../TextHelper";
 
 export class CombinedTwoPeriodesConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "CombinedTwoPeriodesConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
 
         if (dosage.structures === undefined)

--- a/src/main/ts/shorttextconverterimpl/DayInWeekConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/DayInWeekConverterImpl.ts
@@ -6,6 +6,10 @@ import {TextHelper } from "../TextHelper";
 
 export class DayInWeekConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "DayInWeekConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/FreeTextConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/FreeTextConverterImpl.ts
@@ -3,6 +3,10 @@ import { DosageWrapper } from "../vowrapper/DosageWrapper";
 
 export class FreeTextConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "FreeTextConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         return dosage.freeText !== undefined;
     }

--- a/src/main/ts/shorttextconverterimpl/LimitedNumberOfDaysConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/LimitedNumberOfDaysConverterImpl.ts
@@ -15,6 +15,10 @@ import { TextHelper } from "../TextHelper";
  */
 export class LimitedNumberOfDaysConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "LimitedNumberOfDaysConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightAndAccordingToNeedConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightAndAccordingToNeedConverterImpl.ts
@@ -9,6 +9,10 @@ import { TextHelper } from "../TextHelper";
 export class MorningNoonEveningNightAndAccordingToNeedConverterImpl extends ShortTextConverterImpl {
 
 
+    public getConverterClassName(): string {
+        return "MorningNoonEveningNightAndAccordingToNeedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextHelper } from "../TextHelper";
 
 export class MorningNoonEveningNightConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "MorningNoonEveningNightConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightEyeOrEarConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightEyeOrEarConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextHelper } from "../TextHelper";
 
 export class MorningNoonEveningNightEyeOrEarConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "MorningNoonEveningNightEyeOrEarConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightInNDaysConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/MorningNoonEveningNightInNDaysConverterImpl.ts
@@ -12,6 +12,10 @@ import { MorningNoonEveningNightConverterImpl } from "./MorningNoonEveningNightC
  */
 export class MorningNoonEveningNightInNDaysConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "MorningNoonEveningNightInNDaysConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/MultipleDaysNonRepeatedConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/MultipleDaysNonRepeatedConverterImpl.ts
@@ -8,6 +8,10 @@ import { MorningNoonEveningNightConverterImpl } from "./MorningNoonEveningNightC
 
 export class MultipleDaysNonRepeatedConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "MultipleDaysNonRepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/NumberOfWholeWeeksConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/NumberOfWholeWeeksConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextHelper } from "../TextHelper";
 
 export class NumberOfWholeWeeksConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "NumberOfWholeWeeksConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/ParacetamolConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/ParacetamolConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextHelper } from "../TextHelper";
 
 export class ParacetamolConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "ParacetamolConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/RepeatedConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/RepeatedConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextHelper } from "../TextHelper";
 
 export class RepeatedConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "RepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/RepeatedEyeOrEarConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/RepeatedEyeOrEarConverterImpl.ts
@@ -7,6 +7,10 @@ import { TextHelper } from "../TextHelper";
 
 export class RepeatedEyeOrEarConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "RepeatedEyeOrEarConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/ShortTextConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/ShortTextConverterImpl.ts
@@ -6,8 +6,8 @@ import { TextOptions } from "../TextOptions";
 
 export abstract class ShortTextConverterImpl {
 
+    public abstract getConverterClassName(): string;
     public abstract canConvert(dosageStructure: DosageWrapper): boolean;
-
     public abstract doConvert(dosageStructure: DosageWrapper, options: TextOptions ): string;
 
     protected static toValue(dose: DoseWrapper): string {

--- a/src/main/ts/shorttextconverterimpl/SimpleAccordingToNeedConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/SimpleAccordingToNeedConverterImpl.ts
@@ -14,6 +14,10 @@ import { TextHelper } from "../TextHelper";
 
 export class SimpleAccordingToNeedConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "SimpleAccordingToNeedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/SimpleLimitedAccordingToNeedConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/SimpleLimitedAccordingToNeedConverterImpl.ts
@@ -13,6 +13,10 @@ import { TextHelper } from "../TextHelper";
  */
 export class SimpleLimitedAccordingToNeedConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "SimpleLimitedAccordingToNeedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/SimpleNonRepeatedConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/SimpleNonRepeatedConverterImpl.ts
@@ -15,6 +15,10 @@ import { TextHelper } from "../TextHelper";
  */
 export class SimpleNonRepeatedConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "SimpleNonRepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/WeeklyMorningNoonEveningNightConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/WeeklyMorningNoonEveningNightConverterImpl.ts
@@ -10,6 +10,10 @@ import { TextHelper } from "../TextHelper";
 
 export class WeeklyMorningNoonEveningNightConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "WeeklyMorningNoonEveningNightConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;

--- a/src/main/ts/shorttextconverterimpl/WeeklyRepeatedConverterImpl.ts
+++ b/src/main/ts/shorttextconverterimpl/WeeklyRepeatedConverterImpl.ts
@@ -8,6 +8,10 @@ import { TextHelper } from "../TextHelper";
 
 export class WeeklyRepeatedConverterImpl extends ShortTextConverterImpl {
 
+    public getConverterClassName(): string {
+        return "WeeklyRepeatedConverterImpl";
+    }
+
     public canConvert(dosage: DosageWrapper): boolean {
         if (dosage.structures === undefined)
             return false;


### PR DESCRIPTION
LongTextConverterImpl and ShortTextConverterImpl now have methods for returning the class name of the specific converter. The previous use of constructor.name does not work in production where code is minified